### PR TITLE
fix: handle missing xdg-open on headless servers

### DIFF
--- a/packages/core/src/serve.ts
+++ b/packages/core/src/serve.ts
@@ -1065,7 +1065,12 @@ export function handleServe(port?: number, options?: { openBrowser?: boolean; fr
       console.log(`Opened Wave panel`)
     } else if (options?.openBrowser) {
       const openCmd = process.platform === 'darwin' ? 'open' : 'xdg-open'
-      spawn(openCmd, [url], { stdio: 'ignore', detached: true }).unref()
+      const child = spawn(openCmd, [url], { stdio: 'ignore', detached: true })
+      child.on('error', () => {
+        console.log(`Open in browser: ${url}`)
+        console.log(`For remote servers, use SSH port forwarding: ssh -L ${p}:localhost:${p} <user>@<host>`)
+      })
+      child.unref()
       console.log(`Opened browser at ${url}`)
     } else {
       console.log(`Open in browser or Wave panel: wsh web open ${url}`)


### PR DESCRIPTION
## Summary
- When running `npx ggterm-plot setup` on a headless server/cluster without `xdg-open`, the process crashes with an unhandled ENOENT error
- Added an error handler on the spawn call that gracefully falls back to printing the URL with SSH port forwarding instructions
- No behavior change for local/desktop users where `open`/`xdg-open` is available

## Test plan
- [x] Tested on a headless Linux cluster without `xdg-open` — server stays running, URL is printed
- [x] Verified no behavior change for environments where browser opener is available